### PR TITLE
Fix Incorrect Rank Assignment in Torch Distributed Processes During Model Initialization

### DIFF
--- a/model.py
+++ b/model.py
@@ -20,8 +20,6 @@ import torch
 import torch.distributed as dist
 from transformers import AutoTokenizer
 
-from star_attention import LlamaForCausalLM
-
 
 class DistributedInferenceBaseModel:
     def __init__(
@@ -32,6 +30,8 @@ class DistributedInferenceBaseModel:
         block_size: int = -1,
         anchor_block_size: int = -1,
     ):
+        from star_attention import LlamaForCausalLM
+
         self._init_distributed()
 
         # Setup the tokenizer
@@ -77,9 +77,7 @@ class DistributedInferenceBaseModel:
                 f'GPUs Assigned: {", ".join([str(x) for x in self.max_memory.keys()])}'
             )
         else:
-            self.max_memory = None
-            self.rank = 0
-            self.world_size = 1
+            raise RuntimeError('Distributed environment is not initialized!')
 
     def _tokenize(self, text: str) -> torch.Tensor:
         """Tokenize the input text and return the token ids

--- a/run_star_attn_inference.py
+++ b/run_star_attn_inference.py
@@ -22,8 +22,6 @@ from typing import List, Optional
 import torch.distributed as dist
 from tqdm import tqdm
 
-from model import DenseAttentionModel, RingAttentionModel, StarAttentionModel
-
 
 def read_jsonl(filename, num_lines=-1):
     lines = []
@@ -72,6 +70,8 @@ def load_model(
     stop_words=None,
 ):
     if attn_type == 'dense':
+        from model import DenseAttentionModel
+
         model = DenseAttentionModel(
             path=model_path,
             max_new_tokens=tokens_to_generate,
@@ -79,6 +79,8 @@ def load_model(
         )
 
     elif attn_type == 'ring':
+        from model import RingAttentionModel
+
         model = RingAttentionModel(
             path=model_path,
             max_new_tokens=tokens_to_generate,
@@ -86,6 +88,8 @@ def load_model(
         )
 
     elif attn_type == 'star':
+        from model import StarAttentionModel
+
         assert block_size > 0, 'block_size must be provided for star attention'
         model = StarAttentionModel(
             path=model_path,

--- a/star_attention/modeling_llama.py
+++ b/star_attention/modeling_llama.py
@@ -68,8 +68,7 @@ if dist.is_initialized():
     RANK = dist.get_rank()
     WORLD_SIZE = dist.get_world_size()
 else:
-    RANK = 0
-    WORLD_SIZE = 1
+    raise RuntimeError('Distributed environment is not initialized!')
 
 
 class StarLlamaFlashAttention2(LlamaFlashAttention2):

--- a/star_attention/ring_flash_attn/utils.py
+++ b/star_attention/ring_flash_attn/utils.py
@@ -43,17 +43,19 @@ def _update_out_and_lse(
     block_out: torch.Tensor,
     block_lse: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-
     block_out = block_out.to(torch.float32)
     block_lse = block_lse.transpose(-2, -1).unsqueeze(dim=-1)
 
-    # new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
-    # torch.exp(lse - new_lse) * out + torch.exp(block_lse - new_lse) * block_out
+    new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
+    out = torch.exp(lse - new_lse) * out + torch.exp(block_lse - new_lse) * block_out
+
+    # Another variant of LSE update:
     # For additional context and discussion, please refer to:
     # https://github.com/zhuzilin/ring-flash-attention/pull/34#issuecomment-2076126795
-    out = out - F.sigmoid(block_lse - lse) * (out - block_out)
-    lse = lse - F.logsigmoid(lse - block_lse)
+    # out = out - F.sigmoid(block_lse - lse) * (out - block_out)
+    # lse = lse - F.logsigmoid(lse - block_lse)
 
+    lse = new_lse
     return out, lse
 
 

--- a/star_attention/star_flash_attn/utils.py
+++ b/star_attention/star_flash_attn/utils.py
@@ -31,7 +31,6 @@ def _update_out_and_lse(
     block_lse = block_lse.transpose(-2, -1).unsqueeze(dim=-1)
 
     new_lse = lse + torch.log(1 + torch.exp(block_lse - lse))
-
     out = torch.exp(lse - new_lse) * out + torch.exp(block_lse - new_lse) * block_out
 
     lse = new_lse


### PR DESCRIPTION
This PR addresses the issue where incorrect `RANK` and `WORLD_SIZE` values were assigned to torch distributed processes during the execution of `run_star_attn_inference.py`.

### Problem

The script imported the distributed model inference class early in its runtime:
https://github.com/NVIDIA/Star-Attention/blob/443bb9340555af7da192df7f733001f5f00382d7/run_star_attn_inference.py#L25

This occurred before initializing the distributed environment:
https://github.com/NVIDIA/Star-Attention/blob/443bb9340555af7da192df7f733001f5f00382d7/run_star_attn_inference.py#L38-L42

This caused the global variables `RANK` and `WORLD_SIZE` in `modeling_llama.py` get assigned incorrect values:
https://github.com/NVIDIA/Star-Attention/blob/443bb9340555af7da192df7f733001f5f00382d7/star_attention/modeling_llama.py#L67-L72

### Solution

The imports are now moved into the `load_model` function. By the time the model is loaded, the distributed environment is already initialized, ensuring `RANK` and `WORLD_SIZE `have the correct values:
https://github.com/NVIDIA/Star-Attention/blob/3cb2e25f1716c510932c4a733e64c6f1f245fe11/run_star_attn_inference.py#L90-L100

This change ensures correct rank assignments, fixes the distributed accuracy issue, and resolves #2 